### PR TITLE
fix(cloudfront): add webcompo configuration/*.json to invalidation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ runs:
   steps:
     - run: aws s3 sync ${{ inputs.source_dir }} s3://${{ inputs.bucket }} --delete --no-progress --region eu-west-1
       shell: bash
-    - run: aws cloudfront create-invalidation --distribution-id ${{ inputs.cf_dist }} --paths "/css" "/fonts" "/images" "/js" "/favicon.ico" "/index.html"
+    - run: aws cloudfront create-invalidation --distribution-id ${{ inputs.cf_dist }} --paths "/css" "/fonts" "/images" "/js" "/favicon.ico" "/index.html" "/configuration/*.json"
       shell: bash


### PR DESCRIPTION
Actuellement les invalidation de cache cloudfront pour webcomponent ne prennent pas en compte les fichiers de configuration ce qui fait que post-déploiement on a des incohérence entre la configuration sur S3 et la configuration cloudfront en cache