### PR TITLE
feat(cloudfront): allow to add a list of path to invalidate

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,0 +1,1 @@
+FROM 219665457812.dkr.ecr.eu-west-1.amazonaws.com/semantic-release

--- a/.github/action.yml
+++ b/.github/action.yml
@@ -1,0 +1,6 @@
+---
+name: 'Semantic Release'
+description: 'Run semantic-release'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -12,10 +12,17 @@ inputs:
     description: Source directory
     required: false
     default: dist
+  paths_to_invalidate:
+    description: List of path to invalidate
+    required: true
+    default: "/css /fonts /images /js /favicon.ico /index.html /configuration/*.json"
 runs:
   using: 'composite'
   steps:
     - run: aws s3 sync ${{ inputs.source_dir }} s3://${{ inputs.bucket }} --delete --no-progress --region eu-west-1
       shell: bash
-    - run: aws cloudfront create-invalidation --distribution-id ${{ inputs.cf_dist }} --paths "/css" "/fonts" "/images" "/js" "/favicon.ico" "/index.html" "/configuration/*.json"
-      shell: bash
+    - name: Invalidate AWS CloudFront
+      uses: chetan/invalidate-cloudfront-action@v2.4
+      env:
+        DISTRIBUTION: ${{ inputs.cf_dist }}
+        PATHS: ${{ inputs.paths_to_invalidate }}

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,27 @@
+#
+
+## Objectif
+
+{ Liens vers User Story et/ou tâche technique }
+
+## Modifications / ajouts apportés
+
+### Implication / Dangers
+
+A remplir...
+
+## Vérifications
+
+### Documentation
+
+-   [ ] Modification du README.md
+-   [ ] Mettre à jour la représentation du schema
+-   [ ] Mise à jour du `CHANGELOG.md` en mode unreleased
+
+### Tests
+
+-   [ ] Test du module indépendamment sur `sandbox`
+
+### Liste des actions testé
+
+-   [ ] A remplir...


### PR DESCRIPTION
#

## Objectif

[{ Liens vers User Story et/ou tâche technique }
](https://iad-holding.atlassian.net/browse/AWS-2855)

Permettre l'ajout d'une liste de paths à invalider par Cloudfront lors du déploiements.

## Modifications / ajouts apportés

- utilisation de l'action [chetan/invalidate-cloudfront-action@v2.4](https://github.com/chetan/invalidate-cloudfront-action), qui permet de passer en argument une list de paths.
- ajout de l'input paths_to_invalidate, avec comme valeur par défaut, les paths qui étaient à invalider qui étaient déjà configurer.
Ainsi il n'est pas nécessaire de faire  dans l'immédiat le changement sur les workflow qui utilisent cette action.
Il faudra cependant une fois le listing des path à invalider effectuées sur toutes les SPA, modifier la valeur par  défaut avec une valeur plus commune.

Autre:
- ajout de l'action semantic-release, afin de pouvoir versionner cette action
- ajout du template de PR
### Implication / Dangers

A remplir...

## Vérifications

### Documentation

-   [ ] Modification du README.md
-   [ ] Mettre à jour la représentation du schema
-   [ ] Mise à jour du `CHANGELOG.md` en mode unreleased

### Tests

-   [ ] Test du module indépendamment sur `sandbox`

### Liste des actions testé

-  Vérifier l'invalidation des path par défaut
https://github.com/IAD-INTERNATIONAL/mono-vue3/actions/runs/7166155367/job/19509665180
<img width="758" alt="Capture d’écran 2023-12-11 à 11 56 09" src="https://github.com/IAD-INTERNATIONAL/actions-deploy-cloudfront/assets/46197903/1d9247e4-5bc8-47e5-839f-cf5226da7260">
-  Vérifier l'invalidation de path qui sont renseignés via l'input

https://github.com/IAD-INTERNATIONAL/mono-vue3/actions/runs/7166503970/job/19510761640#step:6:590
<img width="751" alt="Capture d’écran 2023-12-11 à 12 08 43" src="https://github.com/IAD-INTERNATIONAL/actions-deploy-cloudfront/assets/46197903/5791c01a-82e8-4fad-a83e-e1765774d342">
